### PR TITLE
Normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Just like the classic FP wisdom: if it doubt, pass it back to the caller to hand
 
 ## Examples
 
-### [Make Safe](https://hexdocs.pm/exceptional/Exceptional.Safe.html))
+### [Make Safe](https://hexdocs.pm/exceptional/Exceptional.Safe.html)
 
 A simple way to declaw a function that normally `raise`s. (Does not change the behaviour of functions that don't `raise`).
 

--- a/lib/exceptional.ex
+++ b/lib/exceptional.ex
@@ -24,6 +24,7 @@ defmodule Exceptional do
   defmacro __using__(opts \\ []) do
     quote bind_quoted: [opts: opts]  do
       use Exceptional.Control, opts
+      use Exceptional.Normalize, opts
       use Exceptional.Pipe, opts
       use Exceptional.Raise, opts
       use Exceptional.TaggedStatus, opts

--- a/lib/exceptional/normalize.ex
+++ b/lib/exceptional/normalize.ex
@@ -1,5 +1,48 @@
 defmodule Exceptional.Normalize do
-  def normalize(thingy) when is_exception?(thingy), do: thingy
 
-  def normalize({:error, message}), do: Exception.normalize(:error, message)
+  defmacro __using__(_) do
+    quote do
+      import unquote(__MODULE__)
+    end
+  end
+
+  @doc ~S"""
+
+      iex> normalize(42)
+      42
+
+      iex> normalize(%Enum.OutOfBoundsError{message: "out of bounds error"})
+      %Enum.OutOfBoundsError{message: "out of bounds error"}
+
+      iex> normalize(:error)
+      %ErlangError{original: nil}
+
+      iex> normalize({:error, "boom"})
+      %ErlangError{original: "boom"}
+
+      iex> normalize({:error, {1, 2, 3}})
+      %ErlangError{original: {1, 2, 3}}
+
+      iex> normalize({:error, "boom with stacktrace", ["trace"]})
+      %ErlangError{original: "boom with stacktrace"}
+
+      iex> normalize({:good, "tuple", ["value"]})
+      {:good, "tuple", ["value"]}
+
+  """
+  @spec normalize(any) :: any
+  def normalize(error_or_value) do
+    case error_or_value do
+      :error           -> %ErlangError{}
+      {:error}         -> %ErlangError{}
+      {:error, detail} -> Exception.normalize(:error, detail)
+
+      plain = {error_type, status, stacktrace} ->
+        err = Exception.normalize(error_type, status, stacktrace)
+        if Exception.exception?(err), do: err, else: plain
+
+      {:ok, value} -> value
+      value -> value
+    end
+  end
 end

--- a/lib/exceptional/normalize.ex
+++ b/lib/exceptional/normalize.ex
@@ -1,0 +1,5 @@
+defmodule Exceptional.Normalize do
+  def normalize(thingy) when is_exception?(thingy), do: thingy
+
+  def normalize({:error, message}), do: Exception.normalize(:error, message)
+end

--- a/lib/exceptional/normalize.ex
+++ b/lib/exceptional/normalize.ex
@@ -1,4 +1,8 @@
 defmodule Exceptional.Normalize do
+  @moduledoc ~S"""
+  Normalize values to a consistent exception struct or plain value.
+  In some ways this can be seen as the opposite of `tagged_tuple`/`ok`.
+  """
 
   defmacro __using__(_) do
     quote do
@@ -7,12 +11,25 @@ defmodule Exceptional.Normalize do
   end
 
   @doc ~S"""
+  Normalizes values into exceptions or plain values (no `{:error, _}` tuples).
+  Some error types may not be detected; you may pass a custom converter.
+  See more below.
+
+  Normal values will simply pass through:
 
       iex> normalize(42)
       42
 
+  Struct exceptions will also pass straight through:
+
       iex> normalize(%Enum.OutOfBoundsError{message: "out of bounds error"})
       %Enum.OutOfBoundsError{message: "out of bounds error"}
+
+  This covers the most common tuple error cases (see examples below), but is by
+  no means exhaustive.
+
+      iex> normalize(:error)
+      %ErlangError{original: nil}
 
       iex> normalize(:error)
       %ErlangError{original: nil}
@@ -26,12 +43,35 @@ defmodule Exceptional.Normalize do
       iex> normalize({:error, "boom with stacktrace", ["trace"]})
       %ErlangError{original: "boom with stacktrace"}
 
+  Some errors tuples cannot be detected.
+  Those cases will be returned as plain values.
+
       iex> normalize({:good, "tuple", ["value"]})
       {:good, "tuple", ["value"]}
 
+  You may optionally pass a converting function as a second argument.
+  This allows you to construct a variant of `normalize` that accounts for
+  some custom error message(s).
+
+      iex> {:oh_no, {"something bad happened", %{bad: :thing}}}
+      ...> |> normalize(fn
+      ...>   {:oh_no, {message, _}} -> %File.Error{reason: message}
+      ...>   {:bang, message}       -> %File.CopyError{reason: message}
+      ...>   otherwise              -> otherwise
+      ...> end)
+      %File.Error{reason: "something bad happened"}
+
+      iex> {:oh_yes, {1, 2, 3}}
+      ...> |> normalize(fn
+      ...>   {:oh_no, {message, _}} -> %File.Error{reason: message}
+      ...>   {:bang, message}       -> %File.CopyError{reason: message}
+      ...>   otherwise              -> otherwise
+      ...> end)
+      {:oh_yes, {1, 2, 3}}
+
   """
-  @spec normalize(any) :: any
-  def normalize(error_or_value) do
+  @spec normalize(any, fun) :: any
+  def normalize(error_or_value, conversion_fun \\ fn x -> x end) do
     case error_or_value do
       :error           -> %ErlangError{}
       {:error}         -> %ErlangError{}
@@ -42,7 +82,7 @@ defmodule Exceptional.Normalize do
         if Exception.exception?(err), do: err, else: plain
 
       {:ok, value} -> value
-      value -> value
+      value -> conversion_fun.(value)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Exceptional.Mixfile do
       name:    "Exceptional",
       description: "Error & exception handling helpers for Elixir",
 
-      version: "1.3.0",
+      version: "1.4.0",
       elixir:  "~> 1.3",
 
       source_url:   "https://github.com/expede/exceptional",

--- a/test/exceptional_test.exs
+++ b/test/exceptional_test.exs
@@ -2,6 +2,7 @@ defmodule Exceptional.PipeTest do
   use ExUnit.Case
 
   doctest Exceptional.Control, [import: true]
+  doctest Exceptional.Normalize, [import: true]
   doctest Exceptional.Pipe, [import: true]
   doctest Exceptional.Raise, [import: true]
   doctest Exceptional.Safe, [import: true]


### PR DESCRIPTION
A long-requested feature. I'm finally caving and writing it 😜

```elixir
normalize(42)
#=> 42

normalize(%Enum.OutOfBoundsError{message: "out of bounds error"})
#=> %Enum.OutOfBoundsError{message: "out of bounds error"}

normalize(:error)
#=> %ErlangError{original: nil}

normalize({:error, "boom"})
#=> %ErlangError{original: "boom"}

normalize({:error, {1, 2, 3}})
#=> %ErlangError{original: {1, 2, 3}}

normalize({:error, "boom with stacktrace", ["trace"]})
#=> %ErlangError{original: "boom with stacktrace"}

normalize({:good, "tuple", ["value"]})
#=> {:good, "tuple", ["value"]}
```

Something similar was suggested back in #2. I still believe that you should pattern match as much as possible, making `normalize` superfluous... but this pipes _well enough_ in most situations.

This isn't a complete solution for all tagged tuples. In fact, it is emphatically _not_ that. For example:

```elixir
normalize({:my_special, "tuple", ["value"]})
#=> {:my_special, "tuple", ["value"]}
```

☝️ You'll still need to handle those cases in pattern matches yourself (unless you do want the tuple value, which is a common case).

The advantage for all of the common patterns is that we have a single struct representation for pattern matching (unless the error tuple is not one of the most common cases). Hopefully including this function doesn't cause any confusion 😨 Time will tell...