### PR TITLE
Fix typo in exception_or_continue docstring

### DIFF
--- a/lib/exceptional/value.ex
+++ b/lib/exceptional/value.ex
@@ -41,7 +41,7 @@ defmodule Exceptional.Value do
   Essentially an `Either` construct for `Exception`s.
 
   Note that this does not catch `raise` or `throw`s. If you want that behaviour,
-  please see `Exceptional.Rescue`.
+  please see `Exceptional.Raise`.
 
   ## Examples
 


### PR DESCRIPTION
The docstring for `exception_or_continue` refers to `Exceptional.Rescue` but there's no such module. From the context I think this is supposed to be a reference to `Exceptional.Raise` (`>>>` and `raise_or_continue`)?

@expede: This is a really nice library, thank you for creating and sharing it!