### PR TITLE
Fix credo issues so Travis CI passes again

### DIFF
--- a/lib/exceptional/control.ex
+++ b/lib/exceptional/control.ex
@@ -69,7 +69,6 @@ defmodule Exceptional.Control do
       ...> end
       "error message"
 
-
       iex> use Exceptional.Control
       ...> ArgumentError.exception("error message")
       ...> |> if_exception do

--- a/lib/exceptional/raise.ex
+++ b/lib/exceptional/raise.ex
@@ -18,7 +18,6 @@ defmodule Exceptional.Raise do
 
   """
 
-
   defmacro __using__(only: :named_functions) do
     quote do
       import unquote(__MODULE__), except: [>>>: 2]

--- a/lib/exceptional/tagged_status.ex
+++ b/lib/exceptional/tagged_status.ex
@@ -18,7 +18,6 @@ defmodule Exceptional.TaggedStatus do
 
   """
 
-
   defmacro __using__(only: :named_functions) do
     quote do
       import unquote(__MODULE__), except: [~~~: 1]


### PR DESCRIPTION
Credo was reporting issues with three instances of "more than 1 consecutive blank lines", which was causing Travis to mark builds as failed.