### PR TITLE
Fix for exception that do not include the message field

### DIFF
--- a/lib/exceptional/tagged_status.ex
+++ b/lib/exceptional/tagged_status.ex
@@ -62,7 +62,7 @@ defmodule Exceptional.TaggedStatus do
 
       value ->
         if Exception.exception?(value) do
-          {:error, value.message}
+          {:error, Exception.message(value)}
         else
           {:ok, value}
         end


### PR DESCRIPTION
Hi!

I've been playing around with Exceptional in our code a little bit and noticed a small problem with the `~~~` operator. It wouldn't really play nice with custom exceptions that do not include the `:message` field (as exceptions are apparently allowed to do according to the docs)

This change makes it work for any exceptions and also makes `normalize/1` and `to_tagged_status/1` somewhat reversible like:

```elixir
{:error, :stuff} |> normalize |> to_tagged_status
```

Let me know what you think :)