### PR TITLE
Remove deprecated (1.15) functions

### DIFF
--- a/lib/exceptional/control.ex
+++ b/lib/exceptional/control.ex
@@ -44,7 +44,7 @@ defmodule Exceptional.Control do
   defmacro branch(maybe_exception, [value_do: value_do, exception_do: exception_do]) do
     quote do
       maybe_exc = unquote(maybe_exception)
-      if Exception.exception?(maybe_exc) do
+      if Kernel.is_exception(maybe_exc) do
         maybe_exc |> unquote(exception_do)
       else
         maybe_exc |> unquote(value_do)
@@ -82,7 +82,7 @@ defmodule Exceptional.Control do
   defmacro if_exception(maybe_exception, do: exception_do, else: value_do) do
     quote do
       maybe_exc = unquote(maybe_exception)
-      if Exception.exception?(maybe_exc) do
+      if Kernel.is_exception(maybe_exc) do
         maybe_exc |> unquote(exception_do)
       else
         maybe_exc |> unquote(value_do)

--- a/lib/exceptional/normalize.ex
+++ b/lib/exceptional/normalize.ex
@@ -79,7 +79,7 @@ defmodule Exceptional.Normalize do
 
       plain = {error_type, status, stacktrace} ->
         err = Exception.normalize(error_type, status, stacktrace)
-        if Exception.exception?(err), do: err, else: plain
+        if Kernel.is_exception(err), do: err, else: plain
 
       {:ok, value} -> value
       value -> conversion_fun.(value)

--- a/lib/exceptional/raise.ex
+++ b/lib/exceptional/raise.ex
@@ -96,7 +96,7 @@ defmodule Exceptional.Raise do
 
   """
   def ensure!(maybe_exception) do
-    if Exception.exception?(maybe_exception) do
+    if Kernel.is_exception(maybe_exception) do
       raise maybe_exception
     else
       maybe_exception

--- a/lib/exceptional/tagged_status.ex
+++ b/lib/exceptional/tagged_status.ex
@@ -61,7 +61,7 @@ defmodule Exceptional.TaggedStatus do
         end
 
       value ->
-        if Exception.exception?(value) do
+        if Kernel.is_exception(value) do
           {:error, Exception.message(value)}
         else
           {:ok, value}

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Exceptional.Mixfile do
       description: "Error & exception handling helpers for Elixir",
 
       version: "2.1.3",
-      elixir:  "~> 1.3",
+      elixir:  "~> 1.11",
 
       source_url:   "https://github.com/expede/exceptional",
       homepage_url: "https://github.com/expede/exceptional",


### PR DESCRIPTION
```
warning: Exception.exception?/1 is deprecated. Use Kernel.is_exception/1 instead
```

starts to occur in Elixir 1.15. This should hopefully fix this, although it does require minimum Elixir version of 1.11 (https://hexdocs.pm/elixir/1.15.4/Kernel.html#is_exception/1) so I have updated `mix.exs` as well.

However that also means CI should be updated, but I am not sure how you'd prefer it? :)